### PR TITLE
gh-pages deploy scripts 업데이트

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "cy:open": "cypress open",
     "cy:component": "nx affected -t cy:component",
     "storybook": "storybook dev -p 6006",
-    "build-storybook": "storybook build",
-    "deploy:storybook": "rimraf storybook-static && yarn build-storybook && gh-pages -d storybook-static",
+    "build:storybook": "storybook build",
+    "deploy:storybook": "rimraf storybook-static && yarn build:storybook && touch ./storybook-static/.nojekyll && gh-pages -d ./storybook-static -t true",
     "type": "tsc --noEmit"
   },
   "devDependencies": {


### PR DESCRIPTION
배포 후 일부 리소스 불러오지 못해 스토리를 볼 수 없는 문제 해결

[관련 이슈](https://github.com/storybookjs/storybook/issues/20564#issuecomment-1385326683)참고하여 배포 디렉토리 내에 `.nojekyll`생성 후 배포